### PR TITLE
Adjust to backend timezone changes

### DIFF
--- a/src/app/(ui)/departures/components/departures-list.tsx
+++ b/src/app/(ui)/departures/components/departures-list.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { ChevronLeft, GitCommit, Heart, Signpost } from 'lucide-react';
 import { LineAndDirectionSign, LineSign } from '@/app/(ui)/lines/components/line-and-direction-sign';
-import { getDisplayTime } from '@/app/(ui)/utils/date-time-utils';
+import { getRelativeDisplayTime } from '@/app/(ui)/utils/date-time-utils';
 import { clsx } from 'clsx';
 
 export default function DeparturesList({stopId}: { stopId: number }) {
@@ -32,7 +32,7 @@ export default function DeparturesList({stopId}: { stopId: number }) {
                                     direction: direction,
                                     type: departures.departures[line].type,
                                     time: departure.scheduledAt,
-                                    displayTime: getDisplayTime(departure.scheduledAt, now)
+                                    displayTime: getRelativeDisplayTime(departure.scheduledAt, now)
                                 } as DepartureDetails)
                             )
                         ).flat()

--- a/src/app/(ui)/departures/components/next-departures-at-stop.tsx
+++ b/src/app/(ui)/departures/components/next-departures-at-stop.tsx
@@ -5,7 +5,7 @@ import { LineAndDirectionSign } from '@/app/(ui)/lines/components/line-and-direc
 import { LineType } from '@/app/model/line-type';
 import { MapPin, Signpost } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { getDisplayTime } from '@/app/(ui)/utils/date-time-utils';
+import { getRelativeDisplayTime } from '@/app/(ui)/utils/date-time-utils';
 import { clsx } from 'clsx';
 
 export default function NextDeparturesAtStop({stopId, stopName, line, direction, type}: {
@@ -29,7 +29,7 @@ export default function NextDeparturesAtStop({stopId, stopName, line, direction,
                     .then((departuresByLine: DeparturesAtStop) => departuresByLine.departures[line].departures[direction])
                     .then(departures => departures.map(d => ({
                         ...d,
-                        displayTime: getDisplayTime(d.scheduledAt, now)
+                        displayTime: getRelativeDisplayTime(d.scheduledAt, now)
                     } as Departure)));
                 if (!!departuresRef.current) {
                     const departing = departuresRef.current[0].displayTime === 'now' && newDepartures[0].displayTime !== 'now';

--- a/src/app/(ui)/schedules/components/departures-table.tsx
+++ b/src/app/(ui)/schedules/components/departures-table.tsx
@@ -6,6 +6,7 @@ import { LineSign } from '@/app/(ui)/lines/components/line-and-direction-sign';
 import { ArrowDown, MapPin } from 'lucide-react';
 import { clsx } from 'clsx';
 import Link from 'next/link';
+import { getDisplayTime } from '@/app/(ui)/utils/date-time-utils';
 
 export default function DeparturesTable({line, departuresAtStop}: {
     line: string,
@@ -70,7 +71,7 @@ export default function DeparturesTable({line, departuresAtStop}: {
                             }
                         )}
                     >
-                        {new Date(departure.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short', timeZone: 'Etc/GMT-1'})}
+                        {getDisplayTime(departure.scheduledAt)}
                     </div>
                 ))}
             </div>

--- a/src/app/(ui)/utils/date-time-utils.ts
+++ b/src/app/(ui)/utils/date-time-utils.ts
@@ -1,7 +1,11 @@
-export function getDisplayTime(time: string, now: Date) {
+export function getRelativeDisplayTime(time: string, now: Date) {
     const waitTimeInMinutes = Math.ceil((new Date(time).getTime() - now.getTime()) / 60_000);
     return waitTimeInMinutes == 0 ? 'now' :
         waitTimeInMinutes <= 10
             ? `${waitTimeInMinutes} min`
-            : new Date(time).toLocaleString('bs-BA', {timeStyle: 'short', timeZone: 'Etc/GMT-1'});
+            : new Date(time).toLocaleString('bs-BA', {timeStyle: 'short'});
+}
+
+export function getDisplayTime(time: string) {
+    return new Date(time).toLocaleString('bs-BA', {timeStyle: 'short'});
 }


### PR DESCRIPTION
Backend now always returns a UTC string that takes into account DST - we can safely display it as it is